### PR TITLE
API 호출을 담당하는 BaseApiService 구현

### DIFF
--- a/packages/base-api-service/BaseApiService.js
+++ b/packages/base-api-service/BaseApiService.js
@@ -10,6 +10,7 @@ export class BaseApiService {
     /**
      * @param {String} baseUrl
      * @param {RequestInit} baseOptions
+     * @param {import("./RequestHandler.js").RequestHandler} requestHandler
      */
     constructor(baseUrl, baseOptions, requestHandler = new RequestHandler()) {
         if (BaseApiService.apiServiceInstance) return BaseApiService.apiServiceInstance;

--- a/packages/base-api-service/BaseApiService.js
+++ b/packages/base-api-service/BaseApiService.js
@@ -1,0 +1,82 @@
+import { RequestHandler } from "./RequestHandler.js";
+
+export class BaseApiService {
+    static apiServiceInstance = null;
+    static baseUrl = "";
+    static baseOptions = {};
+
+    #requestHandler = null;
+
+    /**
+     * @param {String} baseUrl
+     * @param {RequestInit} baseOptions
+     */
+    constructor(baseUrl, baseOptions, requestHandler = new RequestHandler()) {
+        if (BaseApiService.apiServiceInstance) return BaseApiService.apiServiceInstance;
+
+        this.#requestHandler = requestHandler;
+        BaseApiService.baseUrl = baseUrl;
+        BaseApiService.baseOptions = baseOptions;
+        BaseApiService.apiServiceInstance = this;
+    }
+
+    /**
+     * @param {String} endPoint
+     * @param {RequestInit} options
+     * @returns {Promise<Response>}
+     */
+    async #request(endPoint = "", options = {}) {
+        const url = BaseApiService.baseUrl + endPoint;
+        const requestOptions = {
+            headers: { "Content-Type": "application/json" },
+            ...BaseApiService.baseOptions,
+            ...options,
+        };
+        return this.#requestHandler.handleRequest(url, requestOptions);
+    }
+
+    /**
+     * @param {String} endPoint
+     * @param {RequestInit} options
+     */
+    async get(endPoint = "", options = {}) {
+        return this.#request(endPoint, { method: "GET", ...options });
+    }
+
+    /**
+     * @param {String} endPoint
+     * @param {Record<string, any>} body
+     * @param {RequestInit} options
+     */
+    async post(endPoint = "", body = {}, options = {}) {
+        return this.#request(endPoint, {
+            method: "POST",
+            body: JSON.stringify(body),
+            ...options,
+        });
+    }
+
+    /**
+     * @param {String} endPoint
+     * @param {Record<string, any>} body
+     * @param {RequestInit} options
+     */
+    async put(endPoint = "", body = {}, options = {}) {
+        return this.#request(endPoint, {
+            method: "PUT",
+            body: JSON.stringify(body),
+            ...options,
+        });
+    }
+
+    /**
+     * @param {String} endPoint
+     * @param {RequestInit} options
+     */
+    async delete(endPoint = "", options = {}) {
+        return this.#request(endPoint, {
+            method: "DELETE",
+            ...options,
+        });
+    }
+}

--- a/packages/base-api-service/RequestHandler.js
+++ b/packages/base-api-service/RequestHandler.js
@@ -1,0 +1,10 @@
+export class RequestHandler {
+    /**
+     * @param {String} url
+     * @param {RequestInit} options
+     */
+    async handleRequest(url, options = {}) {
+        const response = await fetch(url, options);
+        return response;
+    }
+}

--- a/packages/base-api-service/__tests__/BaseApiService.test.js
+++ b/packages/base-api-service/__tests__/BaseApiService.test.js
@@ -1,0 +1,14 @@
+import { BaseApiService } from "../BaseApiService.js";
+
+const api = new BaseApiService("https://api.themoviedb.org/3", {
+    headers: {
+        Authorization:
+            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJmOTRhMDRkMjU2NGZiNjA2MDU4OWM0YmE1NzU4MWY4MiIsIm5iZiI6MS43NDYwODM0OTE1NjE5OTk4ZSs5LCJzdWIiOiI2ODEzMWVhM2JjYmU3NjIxMTk5YjNhMjYiLCJzY29wZXMiOlsiYXBpX3JlYWQiXSwidmVyc2lvbiI6MX0.vhqein715gcG1j69SS-riJM3P4tHeBIfTRDwTyKV8cA",
+    },
+});
+
+(async () => {
+    const request = await api.get("/movie/top_rated?language=en-US&page=1");
+    const response = await request.json();
+    console.log(response);
+})();


### PR DESCRIPTION
## ✅ Linked Issue

- resolve #1 

## 🔍 What I did

<!-- 이번 PR에서 무엇을 했나요? (변경 사항 요약) -->

- 공통된 `baseUrl` `baseOptions` 로 API 호출을 담당하는 `BaseApiService` 를 구현하였습니다
  - 싱글톤 패턴으로 구현하여 최초에 `BaseApiService` 를 통해 생성된 이후, 인스턴스가 항상 `baseUrl`, `baseOptions` 를 포함한 요청을 하도록 구현하였습니다
- 실제 fetch 요청을 처리하는 `RequestHandler` 로 위임하여 관심사 분리를 진행하였고, `BaseApiService` 의 생성자로부터 `RequestHandler` 를 주입받아 사용할 수 있게 하여 느슨한 결합을 유지했습니다
  - 이를 통해, 실제 테스트시에 `RequestHandler` 와 인터페이스가 동일한 클래스 (예 `MockRequestHandler`) 를 주입받아 테스트에 용이하도록 설계하였습니다

## 🧪 How to test

<!-- 테스트 방법 또는 테스트 결과 캡쳐 (선택사항) -->

- 다른 어떠한 테스트 프레임워크나 라이브러리도 사용할 수 없기에, VSCode 의 Code Runner 를 사용해서 간단하게 API 호출이 정상적으로 동작하는지 확인하는 코드를 작성하였습니다

## 🔧 Additional context

- 웹 애플리케이션 내부에서 단순히 하나의 baseUrl, baseOptions 에 대해서만 요청이 일어난다고 가정하였습니다
  - 만약, 특정 도메인마다 전용 서비스가 필요할때에는 해당 `BaseApiService` 를 상속하는 클래스를 구성하는 방식을 쓰는 방법이 있을것으로 생각됩니다

```js
export class PopularMovieService extends BaseApiService {
  static instance = null;
  constructor() {
    if(PopularMovieService.instance) return PopularMovieService.instance;
    super("domain1.com");
    PopularMovieService.instance = this;
  }
}

export class TopRatedMovieService extends BaseApiService {
  static instance = null;
  constructor() {
    if(TopRatedMovieService.instance) return TopRatedMovieService.instance;
    super("domain2.com");
    TopRatedMovieService.instance = this;
  }
}
```