### PR TITLE
Proxy 기반 반응형 State 및 Web Component, Shadow DOM 을 사용한 BaseComponent 구현

### DIFF
--- a/packages/base-component/BaseComponent.js
+++ b/packages/base-component/BaseComponent.js
@@ -1,0 +1,51 @@
+import { State } from "./State.js";
+
+export class BaseComponent extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: "open" });
+        this.state = new State({}, () => this.reRender());
+    }
+
+    connectedCallback() {
+        this.onBeforeMount();
+        this.reRender();
+        this.onAfterMount();
+    }
+
+    disconnectedCallback() {
+        this.onUnmount();
+    }
+
+    onBeforeMount() {}
+
+    onAfterMount() {}
+
+    onUpdate() {}
+
+    onUnmount() {}
+
+    onEffect() {}
+
+    reRender() {
+        const renderedNode = this.render(this.state);
+
+        if (!(renderedNode instanceof Node)) {
+            throw new Error("render() 메서드는 html tagged template literal 또는 Node를 반환해야 합니다");
+        }
+
+        this.shadowRoot.innerHTML = "";
+        this.shadowRoot.appendChild(renderedNode);
+
+        this.onUpdate();
+        this.onEffect();
+    }
+
+    /**
+     * @param {Record<string,unknown>} state
+     * @returns {Node}
+     */
+    render(state) {
+        throw new Error("render() 메서드가 오버라이드되지 않았습니다");
+    }
+}

--- a/packages/base-component/BaseComponent.js
+++ b/packages/base-component/BaseComponent.js
@@ -31,7 +31,7 @@ export class BaseComponent extends HTMLElement {
         const renderedNode = this.render(this.state);
 
         if (!(renderedNode instanceof Node)) {
-            throw new Error("render() 메서드는 html tagged template literal 또는 Node를 반환해야 합니다");
+            throw new Error("render() 메서드는 html tagged template literal 또는 Node를 반환해야 합니다. 현재 반환 값 타입: " + typeof renderedNode);
         }
 
         this.shadowRoot.innerHTML = "";

--- a/packages/base-component/State.js
+++ b/packages/base-component/State.js
@@ -1,0 +1,20 @@
+export class State {
+    constructor(initialState = {}, onChange = () => {}) {
+        return new Proxy(initialState, {
+            set(target, key, value) {
+                if (target[key] !== value) {
+                    target[key] = value;
+                    onChange(key, value);
+                }
+                return true;
+            },
+            deleteProperty(target, key) {
+                if (key in target) {
+                    delete target[key];
+                    onChange(key, undefined);
+                }
+                return true;
+            },
+        });
+    }
+}

--- a/packages/base-component/State.js
+++ b/packages/base-component/State.js
@@ -2,7 +2,7 @@ export class State {
     constructor(initialState = {}, onChange = () => {}) {
         return new Proxy(initialState, {
             set(target, key, value) {
-                if (target[key] !== value) {
+                if (JSON.stringify(target[key]) !== JSON.stringify(value)) {
                     target[key] = value;
                     onChange(key, value);
                 }

--- a/packages/base-component/__test__/State.test.js
+++ b/packages/base-component/__test__/State.test.js
@@ -1,0 +1,15 @@
+import { State } from "../State.js";
+
+const state = new State({ count: 0 }, (key, value) => {
+    console.log("rerendered : ", key, value);
+});
+
+(() => {
+    const interval = setInterval(() => {
+        state.count++;
+    }, 1000);
+
+    setTimeout(() => {
+        clearInterval(interval);
+    }, 5000);
+})();

--- a/packages/html-tagged-template-literal/HTMLTaggedTemplateLiteral.js
+++ b/packages/html-tagged-template-literal/HTMLTaggedTemplateLiteral.js
@@ -1,0 +1,11 @@
+export function html(htmlStrings, ...values) {
+    const template = document.createElement("template");
+
+    const rawHTML = htmlStrings.reduce((acc, str, i) => {
+        const val = values[i] ?? "";
+        return acc + str + val;
+    }, "");
+
+    template.innerHTML = rawHTML;
+    return template.content;
+}

--- a/packages/html-tagged-template-literal/__test__/HTMLTaggedTemplateLiteral.test.js
+++ b/packages/html-tagged-template-literal/__test__/HTMLTaggedTemplateLiteral.test.js
@@ -1,0 +1,17 @@
+import { html } from "../HTMLTaggedTemplateLiteral.js";
+
+let _string = "string";
+let _number = 123;
+let _boolean = true;
+let _array = [1, 2, 3];
+
+const template = html`
+    <div>
+        <h1>${_string}</h1>
+        <p>${_number}</p>
+        <p>${_boolean}</p>
+        <p>${_array.join(", ")}</p>
+    </div>
+`;
+
+console.log(template);

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,0 +1,49 @@
+import { BaseComponent } from "../../packages/base-component/BaseComponent.js";
+import { html } from "../../packages/html-tagged-template-literal/HTMLTaggedTemplateLiteral.js";
+
+export class Counter extends BaseComponent {
+    constructor() {
+        super();
+        this.state.count = 0;
+    }
+
+    #increaseCount() {
+        this.state.count++;
+    }
+    #decreaseCount() {
+        this.state.count--;
+    }
+
+    onUpdate() {
+        console.log("counter : ", this.state.count);
+    }
+
+    onEffect() {
+        const $increaseBtn = this.shadowRoot.querySelector("#increase");
+        $increaseBtn.addEventListener("click", this.#increaseCount.bind(this));
+
+        const $decreaseBtn = this.shadowRoot.querySelector("#decrease");
+        $decreaseBtn.addEventListener("click", this.#decreaseCount.bind(this));
+    }
+
+    onUnmount() {
+        const $increaseBtn = this.shadowRoot.querySelector("#increase");
+        $increaseBtn.removeEventListener("click", this.#increaseCount.bind(this));
+
+        const $decreaseBtn = this.shadowRoot.querySelector("#decrease");
+        $decreaseBtn.removeEventListener("click", this.#decreaseCount.bind(this));
+    }
+
+    render() {
+        return html`
+            <div>
+                <h1>Counter</h1>
+                <p>count : ${this.state.count}</p>
+                <button id="increase">+</button>
+                <button id="decrease">-</button>
+            </div>
+        `;
+    }
+}
+
+customElements.define("my-counter", Counter);


### PR DESCRIPTION
## ✅ Linked Issue

- resolve #5 

## 🔍 What I did
- tagged template literal 을 통한 `html` 템플릿 유틸리티 함수 구현
- Proxy 객체를 통한 반응형 `State` 구현
- Web Component, Shadow DOM 을 사용한 `BaseComponent` 구현

## 🧠 What I learned

<!-- 작업하면서 배운 점, 알게 된 개념이 있다면 정리 -->

1. Tagged Template Literal
  - JS 엔진에서 실행 컨텍스트 execution phase 에서 문자열과 값을 분리해서 전달받음
  - 첫번째 인자로 문자열 배열, 두번째 인자로 `${ }` 값에 대한 배열을 전달받아 호출됨
- HTML `<template>` 요소
  - https://developer.mozilla.org/ko/docs/Web/HTML/Reference/Elements/template
  - html 을 불러온다고 렌더링되지 않고, JS 를 사용해 인스턴스를 생성할 수 있는 html 코드 블럭 (비활성화된, 실제 DOM 트리에 붙지 않은 DOM 트리?)
  - `template.content`는 `<template>` 내부 DOM 노드가 담긴 `DocumentFragment` (리액트의 `<Fragment/> 와 유사하게 렌더링되지 않고 여러 노드를 하나로 묶기 위한 용도)
  - 실제 DOM 에 붙기 전까지 비활성화 상태(inert) 임
  - `template.content.cloneNode(true)` 를 사용해서 template DOM 트리의 깊은 복사를 사용해 실제 DOM 에 attach
2. `WebComponent`
- `HTMLElement` 를 extend 한 클래스 정의 후 `customElement.define()`을 통해 사용자 정의 태그를 만들 수 있다
  - `connectedCallback()` : DOM 에 마운트되었을때 실행되는 함수
  - `disconnectedCallback()` : DOM 에서 언마운트되었을때 실행되는 함수
  - `attributeChangedCallback()` : 속성이 변경되었을때 실행되는 함수
    - `static get observedAttributes() { return [] }`메서드에서 감지할 props 의 문자열 배열을 등록할 수 있다
  - WebComponent 의 Shadow DOM 내부에 `<slot>` 을 사용하면 custom element 사이에 들어오는 컨텐츠가 `<slot>` 자리에 들어옴 (리액트의 props.children 과 유사)
    - WebComponent `<slot name="">` 으로 named slot 을 지정하고, `<my-element><p name="">content</p></my-element>` 과 같이 해당 named slot 에 들어갈 요소를 명시할수도 있음
```js
class MyComponent extends HTMLElement {
    constructor() {
        super();
    }
}
customElements.define("my-component", MyComponent);
```
```html
<my-component></my-component>
```

4. Shadow DOM 을 통해 Web Component 내부에 실제 DOM 요소를 캡슐화 할 수 있음
- 외부 스타일, 스크립트의 간섭 없이 독립된 UI 컴포넌트를 만들 수 있음
```js
class MyComponent extends HTMLComponent {
    constructor() {
        super();
        this.attachShadow({ mode: "open" }); // "open" 인 경우 JS 로 해당 shadow element 에 접근 할 수 있음 (this.shadowRoot....)
        this.shadowRoot.appendChild(renderedNode); // 또는 this.shadowRoot.innerHTML
    }
}
```
5. `Proxy` 객체
- https://ko.javascript.info/proxy
- 함수를 제외한 객체를 감싸서 프로퍼티 읽기, 쓰기 등 해당 객체에 적용되는 연산을 중간에서 가로채서 처리할 수 있음
  - `const proxy = new Proxy(target, handler);`
  - 감싼 `target` 객체에 대해 `handler` 객체 내부 핸들러메서드로 처리 (`get`, `set`, `deleteProperty` 등)
```js
const proxy = new Proxy(target, {
    get(target, key) {}
    set(target, key, value) { return true; } 
    // ...
});
```

## 🔧 Additional context

<!-- 관련된 이슈, 레퍼런스, 고민한 점 등 -->

- `State` 와 같은 객체를 클래스로 선언하는것과 함수로 선언하는것과의 차이점
  - `new State()` vs `createState()` ??

## 🚧 TODO (if any)

<!-- 남은 작업이 있다면 적어주세요 -->

- `State`에서 원시값이 아닌 값이 들어왔을 때에도 프록시가 정상 동작하도록 수정 필요할듯
