### PR TITLE
Observer 패턴을 사용한 전역 상태 관리 기능 구현

### DIFF
--- a/packages/base-component/BaseGlobalState.js
+++ b/packages/base-component/BaseGlobalState.js
@@ -1,0 +1,36 @@
+import { State } from "./State.js";
+
+export class BaseGlobalState {
+    static globalStateInstance = null;
+
+    /** @type {Map<import("./BaseComponent.js").BaseComponent, Function>} */
+    #subscribers = null;
+
+    constructor(initialState = {}) {
+        if (BaseGlobalState.globalStateInstance) {
+            return BaseGlobalState.globalStateInstance;
+        }
+        BaseGlobalState.globalStateInstance = this;
+
+        this.state = new State(initialState, this.dispatch.bind(this));
+        this.#subscribers = new Map();
+    }
+
+    dispatch() {
+        this.#subscribers.forEach((reRenderFunction) => {
+            reRenderFunction();
+        });
+    }
+
+    /**
+     * @param {import("./BaseComponent.js").BaseComponent} webComponentInstance
+     * @param {Function} reRenderFunction
+     */
+    subscribe(webComponentInstance, reRenderFunction) {
+        this.#subscribers.set(webComponentInstance, reRenderFunction);
+    }
+
+    unsubscribe() {
+        this.#subscribers.delete(this);
+    }
+}

--- a/packages/base-component/BaseGlobalState.js
+++ b/packages/base-component/BaseGlobalState.js
@@ -30,7 +30,9 @@ export class BaseGlobalState {
         this.#subscribers.set(webComponentInstance, reRenderFunction);
     }
 
-    unsubscribe() {
-        this.#subscribers.delete(this);
+    unsubscribe(webComponentInstance) {
+        // #subscribers Map 에서 this 를 삭제하는경우, GlobalState 가 제거됨
+        // 실제 webComponentInstance 를 Map 에서 삭제해야함
+        this.#subscribers.delete(webComponentInstance);
     }
 }

--- a/packages/base-component/__test__/BaseGlobalState.test.js
+++ b/packages/base-component/__test__/BaseGlobalState.test.js
@@ -1,0 +1,37 @@
+import { BaseGlobalState } from "../BaseGlobalState.js";
+import { test, expect } from "../../__test__/test.js";
+
+class GlobalState extends BaseGlobalState {
+    static instance = null;
+
+    constructor() {
+        if (GlobalState.instance) {
+            return GlobalState.instance;
+        }
+        super();
+        this.state.count = 0;
+        GlobalState.instance = this;
+    }
+}
+
+class TestComponent {
+    reRenderFunctionCalled = false;
+
+    constructor() {
+        this.globalState = new GlobalState();
+        this.globalState.subscribe(this, this.reRender.bind(this));
+    }
+
+    // 실제 BaseComponent extends 하는 경우 onUnMount 에서 구독해제 해야함!
+
+    reRender() {
+        this.reRenderFunctionCalled = true;
+    }
+}
+
+test("GlobalState 가 변경되면 구독한 컴포넌트가 바인딩한 함수가 호출됩니다", () => {
+    const testComponent = new TestComponent();
+    testComponent.globalState.state.count++;
+
+    expect(testComponent.reRenderFunctionCalled).toBe(true);
+});

--- a/packages/base-component/__test__/BaseGlobalState.test.js
+++ b/packages/base-component/__test__/BaseGlobalState.test.js
@@ -33,5 +33,9 @@ test("GlobalState 가 변경되면 구독한 컴포넌트가 바인딩한 함수
     const testComponent = new TestComponent();
     testComponent.globalState.state.count++;
 
+    // 실제 BaseComponent extends 하는 경우 onUnMount 에서 구독해제 해야함!
+    // 테스트용으로 GlobalState 명시적으로 gc 가 수거해가도록
+    GlobalState.instance = null;
+
     expect(testComponent.reRenderFunctionCalled).toBe(true);
 });


### PR DESCRIPTION
## ✅ Linked Issue

- resolve #9 

## 🔍 What I did

- observer 패턴을 사용하여 전역 상태관리 기능을 구현하였습니다
  - `subscribe()` 메서드를 통해 `BaseComponent` 를 상속한 웹컴포넌트와 재렌더링함수를 구독합니다
  - 전역상태에서 변경이 일어나면 Proxy 객체를 통해 `dispatch()` 메서드가 호출됩니다
  - `dispatch()` 메서드에서는 구독하고 있는 `#subscribers` 필드를 순회하면서 재렌더링함수를 호출합니다

## 💡 Why I did it

<!-- 이렇게 구현하거나 변경한 이유는? (의도/배경/기획) -->

- 전역상태는 전역에 한개만 존재하므로 싱글톤 패턴을 사용하여 `BaseGlobalState` 를 구현함
- 슬라이스 단위로 도메인 전역상태를 관심사를 분리하여 구독하고있는 `GlobalState`에 대해서만 재렌더링이 되도록 구현함

- `BaseGlobalState` 를 일반 `Map` 으로 사용한 이유
  - WeakMap 은 순회가 불가능하기 때문에 WeakMap 의 모든 키 (BaseComponent) 를 순회하며 dispatch 할 수 없음
  - 대신에 개발자가 BaseComponent 의 onUnmount 에서 반드시 명시적으로 unsubscribe 를 해주어야함

## 🧠 What I learned

<!-- 작업하면서 배운 점, 알게 된 개념이 있다면 정리 -->

- 옵저버 패턴
  - https://refactoring.guru/ko/design-patterns/observer
  - 크게 Publisher, Subscriber 두개의 역할을 담당하는 클래스로 나눠짐
  - Publisher
    - subscriber 를 관리하는 메서드 subscribe, unsubscribe 가 존재하고
    - subscriber 에게 이벤트가 발생할 경우 알리는 notify 또는 dispatch 메서드가 존재함
- WeakMap
  - 원래 맵은 `{key, value}` 쌍을 저장할 수 있는 객체
  - 근데 key 값이 객체인경우 객체에 대한 강한 참조를 가짐
  - 그래서 해당 객체를 참조하고있는 식별자 바인딩이 해제 되더라도 map 이 해당 객체를 참조하기 때문에 gc 수거대상이 되지않아 메모리 누수가 발생함
  - WeakMap 은 약한 참조를 가지고 있기 때문에 키 객체를 더이상 사용못하는경우 gc 에서 수거해감
  - 단, weak map 은 순회 불가

## 🧪 How to test

<!-- 테스트 방법 또는 테스트 결과 캡쳐 (선택사항) -->

- 기존에 작성한 테스트 유틸리티 함수를 사용함
  - TestComponent 클래스를 만들고 GlobalState 를 구독 
  - reRenderFunctionCalled 필드를 추가하고 전역상태가 변경된 경우 reRenderFunctionCalled 필드를 true로 변경
  - expect 를 통해 reRenderFunctionCalled 필드가 true 로 변경되었는지 확인
