### PR TITLE
Web Component 의 observedAttributes 변경에 대한 재렌더링 기능 구현

### DIFF
--- a/packages/base-component/BaseComponent.js
+++ b/packages/base-component/BaseComponent.js
@@ -22,6 +22,7 @@ export class BaseComponent extends HTMLElement {
     }
 
     attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
         this.reRender();
     }
 

--- a/packages/base-component/BaseComponent.js
+++ b/packages/base-component/BaseComponent.js
@@ -1,6 +1,10 @@
 import { State } from "./State.js";
 
 export class BaseComponent extends HTMLElement {
+    static get observedAttributes() {
+        return [];
+    }
+
     constructor() {
         super();
         this.attachShadow({ mode: "open" });
@@ -15,6 +19,10 @@ export class BaseComponent extends HTMLElement {
 
     disconnectedCallback() {
         this.onUnmount();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        this.reRender();
     }
 
     onBeforeMount() {}

--- a/packages/html-tagged-template-literal/HTMLTaggedTemplateLiteral.js
+++ b/packages/html-tagged-template-literal/HTMLTaggedTemplateLiteral.js
@@ -7,5 +7,5 @@ export function html(htmlStrings, ...values) {
     }, "");
 
     template.innerHTML = rawHTML;
-    return template.content;
+    return template.content.cloneNode(true);
 }


### PR DESCRIPTION
## ✅ Linked Issue

- resolve #13 

## 🔍 What I did

- `observedAttributes` 에서 리턴하는 attributes 가 변경시 재렌더링 함수를 호출합니다

## 🧠 What I learned

<!-- 작업하면서 배운 점, 알게 된 개념이 있다면 정리 -->

- Web Component 에서 사용자 정의 attributes 에 대한 변경을 감지 할 수 있음
  - 감지할 attributes 들은 `static get observedAttributes()` dptj `Array<String>` 형태로 등록함
  - 해당 attribute 변경시 `attributeChangeCallback()` 이 호출됨

## 🔧 Additional context

- `BaseComponent` 를 상속하는 하위클래스에서 `observedAttributes` 정적 메서드를 오버라이드 하지 않을시 에러 터뜨리고 싶은데 어떻게 해야될지 모르겠음