### PR TITLE
html tagged template literal 에서 배열 값을 올바르게 처리하도록 수정

### DIFF
--- a/packages/html-tagged-template-literal/HTMLTaggedTemplateLiteral.js
+++ b/packages/html-tagged-template-literal/HTMLTaggedTemplateLiteral.js
@@ -2,8 +2,19 @@ export function html(htmlStrings, ...values) {
     const template = document.createElement("template");
 
     const rawHTML = htmlStrings.reduce((acc, str, i) => {
-        const val = values[i] ?? "";
-        return acc + str + val;
+        const value = values[i] ?? "";
+
+        /**
+         * @todo
+         * 여기서 value instanceof Node || value instanceof HTMLFragment 인경우
+         * 예를들어, html`${arr.map((item) => html`<div>${item}</div>`)}`
+         * 이런 경우에 대해서도 처리해줘야하는데 어떻게 해야할지 모르겠음
+         *
+         * 우선은 재귀적으로 안들어온다고 가정하고 처리함
+         */
+        if (value instanceof Array) return acc + str + value.join("");
+
+        return acc + str + value;
     }, "");
 
     template.innerHTML = rawHTML;


### PR DESCRIPTION
## ✅ Linked Issue

- resolve #16 

## 🔍 What I did
- `value instanceof Array` 로 html tagged template literal 내부 값이 배열의 인스턴스인 경우 `join("")`으로 `,` 를 제외한 값을 렌더링합니다

## 🚧 TODO (if any)

<!-- 남은 작업이 있다면 적어주세요 -->
- 다음과 같이 html 내부 html 이 렌더링되는경우에 대한 처리가 필요
- 현재는 `[object DocumentFragment]` 문자열로 렌더링됨
```js
class Component extends BaseComponent {
  render() {
    return html`
          ${arr.map((item) => {
               return html`
                  <div>{item.property}</div>
               `
          }`;
    `;
}
```
